### PR TITLE
Add a GitHub Actions workflow for publishing release artifacts.

### DIFF
--- a/.github/build-linux.sh
+++ b/.github/build-linux.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+apt-get update -y || exit 1
+apt-get install -y build-essential libssl-dev || exit 1
+
+make -C /build/lib || exit 1
+
+cd /build || exit 1
+# shellcheck disable=SC2154
+tar -cvzf "libmosquitto-${tag}-${arch}".tar.gz lib/libmosquitto.a lib/*.h || exit 1

--- a/.github/build-linux.sh
+++ b/.github/build-linux.sh
@@ -7,4 +7,4 @@ make -C /build/lib || exit 1
 
 cd /build || exit 1
 # shellcheck disable=SC2154
-tar -cvzf "libmosquitto-${tag}-${arch}".tar.gz lib/libmosquitto.a lib/*.h || exit 1
+tar -cvzf "libmosquitto-${tag}-linux-${arch}".tar.gz lib/libmosquitto.a lib/*.h || exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Release Artifacts
 on: release
 jobs:
   build-linux:
-    name: Build Linux amd64
+    name: Build Linux
     runs-on: ubuntu-latest
     env:
       CONTAINER: debian:stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Upload
         uses: JasonEtco/upload-to-release@master
           with:
-            args: libmosquitto-${{ github.event.release.tag_name }}-${{ matrix.arch }}.tar.gz application/gzip
+            args: libmosquitto-${{ github.event.release.tag_name }}-linux-${{ matrix.arch }}.tar.gz application/gzip
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         arch: ['amd64', 'i386', 'arm32v7', 'arm64v8', 'arm32v6']
-    jobs:
+    steps:
       - name: Check Out
         uses: actions/checkout@v1
       - name: Prepare Docker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           docker run -it -e arch=${{ matrix.arch }} -e tag=${{ github.event.release.tag_name }} -v $PWD:/build ${{ matrix.arch }}/${{ CONTAINER }} /build/.github/build-linux.sh
       - name: Upload
         uses: JasonEtco/upload-to-release@master
-          with:
-            args: libmosquitto-${{ github.event.release.tag_name }}-linux-${{ matrix.arch }}.tar.gz application/gzip
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: libmosquitto-${{ github.event.release.tag_name }}-linux-${{ matrix.arch }}.tar.gz application/gzip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build Release Artifacts
+on: release
+jobs:
+  build-linux:
+    name: Build Linux amd64
+    runs-on: ubuntu-latest
+    env:
+      CONTAINER: debian:stable
+    strategy:
+      matrix:
+        arch: ['amd64', 'i386', 'arm32v7', 'arm64v8', 'arm32v6']
+    jobs:
+      - name: Check Out
+        uses: actions/checkout@v1
+      - name: Prepare Docker
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker pull ${{ matrix.arch }}/${{ CONTAINER }}
+      - name: Build
+        run: |
+          docker run -it -e arch=${{ matrix.arch }} -e tag=${{ github.event.release.tag_name }} -v $PWD:/build ${{ matrix.arch }}/${{ CONTAINER }} /build/.github/build-linux.sh
+      - name: Upload
+        uses: JasonEtco/upload-to-release@master
+          with:
+            args: libmosquitto-${{ github.event.release.tag_name }}-${{ matrix.arch }}.tar.gz application/gzip
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This produces release artifacts for Linux systems and then uploads them when a release is created.

The resultant artifacts can then be used by the regular Netdata build process.

For the moment, this only handles Linux (though it covers 32 and 64 bit x86 and ARM). FreeBSD and macOS handling will be added later by separate PR's.