### PR TITLE
cleanup mosquitto patch for upstream attempt

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -193,6 +193,12 @@ int net__socket_close(struct mosquitto *mosq)
 	int rc = 0;
 
 	assert(mosq);
+
+	if(mosq->sock == PLACEHOLDER_SOCKET) {
+		mosq->sock = INVALID_SOCKET;
+		return MOSQ_ERR_SUCCESS;
+	}
+
 #ifdef WITH_TLS
 #ifdef WITH_WEBSOCKETS
 	if(!mosq->wsi)
@@ -824,15 +830,19 @@ int net__socket_connect_step3(struct mosquitto *mosq, const char *host)
 /* Create a socket and connect it to 'ip' on port 'port'.  */
 int net__socket_connect(struct mosquitto *mosq, const char *host, uint16_t port, const char *bind_address, bool blocking)
 {
-	if(mosq->external_write_fnc) {
-		mosq->sock = 777;
-		return MOSQ_ERR_SUCCESS;
-	}
-
 	mosq_sock_t sock = INVALID_SOCKET;
 	int rc, rc2;
 
-	if(!mosq || !host || !port) return MOSQ_ERR_INVAL;
+	if(!mosq)
+		return MOSQ_ERR_INVAL;
+
+	if(mosq->external_write_fnc){
+		mosq->sock = PLACEHOLDER_SOCKET;
+		return MOSQ_ERR_SUCCESS;
+	}
+
+	if(!host || !port)
+		return MOSQ_ERR_INVAL;
 
 	rc = net__try_connect(host, port, &sock, bind_address, blocking);
 	if(rc > 0) return rc;

--- a/lib/net_mosq.h
+++ b/lib/net_mosq.h
@@ -48,6 +48,8 @@ struct mosquitto_db;
 #define INVALID_SOCKET -1
 #endif
 
+#define PLACEHOLDER_SOCKET -2
+
 /* Macros for accessing the MSB and LSB of a uint16_t */
 #define MOSQ_MSB(A) (uint8_t)((A & 0xFF00) >> 8)
 #define MOSQ_LSB(A) (uint8_t)(A & 0x00FF)


### PR DESCRIPTION
Cleans the thing up in attempt to PR upstream.

Tested with staging by linking netdata with this version of mosquitto.
Also connection drops and reconnection still works tested by:
`ss -K dst 192.168.1.214` and unplugging network cable