### PR TITLE
Fix missing mach/mach_time.h header on OS X

### DIFF
--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -24,6 +24,10 @@ Contributors:
 #include <strings.h>
 #endif
 
+#if defined(__APPLE__)
+#  include <mach/mach_time.h>
+#endif
+
 #include "mosquitto.h"
 #include "mosquitto_internal.h"
 #include "memory_mosq.h"


### PR DESCRIPTION
as per description

taken from upstream (https://github.com/eclipse/mosquitto/issues/1831)

Somebody with MacOS plz test